### PR TITLE
feat: add EfficientNet-B1 v1 (0.91 MCC)

### DIFF
--- a/ai_detector_model/api/model_factory.py
+++ b/ai_detector_model/api/model_factory.py
@@ -3,7 +3,7 @@ import re
 
 import torch
 import torch.nn as nn
-from torchvision.models import efficientnet_b0
+from torchvision.models import efficientnet_b0, efficientnet_b1
 
 from ai_detector_model.api.model_schema import ModelMetadata
 
@@ -13,6 +13,10 @@ class ModelFactory:
     def get_pytorch_model(model_name: str, num_classes: int):
         if model_name == "EFFICIENTNET-B0":
             model = efficientnet_b0(weights=None)
+            model.classifier[1] = nn.Linear(model.classifier[1].in_features, num_classes - 1)
+            return model
+        elif model_name == "EFFICIENTNET-B1":
+            model = efficientnet_b1(weights=None)
             model.classifier[1] = nn.Linear(model.classifier[1].in_features, num_classes - 1)
             return model
         else:

--- a/configs/model/efficientnet_b1.yaml
+++ b/configs/model/efficientnet_b1.yaml
@@ -1,0 +1,7 @@
+model_name: 'EFFICIENTNET-B1'
+model_type: 'efficientnet'
+pretrained: true
+input_size: 240
+estimator:
+  _target_: torchvision.models.efficientnet_b1
+  weights: 'DEFAULT'

--- a/models/pytorch/diffusion_model_recognition_v1/metadata.json
+++ b/models/pytorch/diffusion_model_recognition_v1/metadata.json
@@ -1,0 +1,26 @@
+{
+  "registered_model_name": "diffusion_model_recognition",
+  "model_version": "1",
+  "model_uri": "models:/diffusion_model_recognition/1",
+  "run_id": "dde84c973a0a4c08bf48973365625175",
+  "source": "models:/m-d946c7589438429498a002c177d17d2c",
+  "status": "READY",
+  "run_name": "capable-auk-759",
+  "model_name": "EFFICIENTNET-B1",
+  "model_type": "efficientnet",
+  "input_size": 240,
+  "class_to_idx": "{'0_real': 0, '1_fake': 1}",
+  "device": "cuda",
+  "use_amp": "True",
+  "metrics": {
+    "train_loss_epoch": 0.06748481941633507,
+    "lr": 0.0001,
+    "accuracy": 0.9537693858146667,
+    "f1": 0.9519846439361572,
+    "mcc": 0.9075583815574646,
+    "precision": 0.9433844685554504,
+    "recall": 0.9607430100440979,
+    "validation_loss": 0.13498950900656562,
+    "training_loss": 0.06748481941633507
+  }
+}


### PR DESCRIPTION
This PR introduces a new production-ready model for AI image detection. 
I have upgraded the architecture from EfficientNet-B0 to EfficientNet-B1 and trained it on a significantly more diverse and balanced dataset. 
Trained on a balanced subset of 600,000 images (500k train / 100k test) from the ArtiFact collection, covering 25 different AI generators.
Achived metrics:
    "train_loss_epoch": 0.06748481941633507,
    "lr": 0.0001,
    "accuracy": 0.9537693858146667,
    "f1": 0.9519846439361572,
    "mcc": 0.9075583815574646,
    "precision": 0.9433844685554504,
    "recall": 0.9607430100440979,
    "validation_loss": 0.13498950900656562,
    "training_loss": 0.06748481941633507